### PR TITLE
fix: remove base path from glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launchdarkly-cypress-plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Skip cypress tests using LaunchDarkly feature flags",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -22,14 +22,13 @@ export const launchDarklyCypressPlugin = async (
   infoLog('Using LaunchDarkly cypress plugin');
 
   const specFiles = fg.sync(cyCfg.specPattern, {
-    cwd: 'cypress/e2e',
     ignore: sanitizeFilesToIgnore(cyCfg.excludeSpecPattern),
     absolute: false,
   });
 
   debugLog(`Found ${specFiles.length} test files for filtering`);
 
-  const testData = parseTestData('cypress/e2e', specFiles);
+  const testData = parseTestData('', specFiles);
   const testsToSkip: TestData[] = [];
 
   for (const td of testData) {


### PR DESCRIPTION
Remove base path `cypress/e2e` from globs as [specPattern](https://docs.cypress.io/guides/references/configuration#e2e) already includes it.